### PR TITLE
Sb annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ project.ext.moduleName = 'com.synopsys.integration.hub-imageinspector-lib'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '14.0.0'
+version = '14.0.1-SNAPSHOT'
 description = 'A library for creating Black Duck Input Output (BDIO) representing the packages installed in a Linux Docker image'
 
 apply plugin: "io.spring.dependency-management"

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolver.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolver.java
@@ -13,25 +13,32 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
 
+@Component
 public class ImageNameResolver {
 
-    public NameValuePair resolve(@Nullable String givenImageName) {
-        Optional<String> newImageRepo = Optional.empty();
-        Optional<String> newImageTag = Optional.empty();
-        if (StringUtils.isNotBlank(givenImageName)) {
-            newImageTag = Optional.of("latest");
-            final int tagColonIndex = findColonBeforeTag(givenImageName);
+    public NameValuePair resolve(@Nullable String foundImageName, @Nullable String givenRepo, @Nullable String givenTag) {
+        givenRepo = Optional.ofNullable(givenRepo).orElse("");
+        givenTag = Optional.ofNullable(givenTag).orElse("");
+        if (StringUtils.isBlank(foundImageName)) {
+            return new BasicNameValuePair(givenRepo, givenTag);
+        }
+        String resolvedImageRepo = givenRepo;
+        String resolvedImageTag = givenTag;
+        if (StringUtils.isNotBlank(foundImageName)) {
+            resolvedImageTag = "latest";
+            final int tagColonIndex = findColonBeforeTag(foundImageName);
             if (tagColonIndex < 0) {
-                newImageRepo = Optional.of(givenImageName);
+                resolvedImageRepo = foundImageName;
             } else {
-                newImageRepo = Optional.of(givenImageName.substring(0, tagColonIndex));
-                if (tagColonIndex + 1 != givenImageName.length()) {
-                    newImageTag = Optional.of(givenImageName.substring(tagColonIndex + 1));
+                resolvedImageRepo = foundImageName.substring(0, tagColonIndex);
+                if (tagColonIndex + 1 != foundImageName.length()) {
+                    resolvedImageTag = foundImageName.substring(tagColonIndex + 1);
                 }
             }
         }
-        return new BasicNameValuePair(newImageRepo.orElse(""), newImageTag.orElse(""));
+        return new BasicNameValuePair(resolvedImageRepo, resolvedImageTag);
     }
 
     private int findColonBeforeTag(final String givenImageName) {

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolver.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolver.java
@@ -9,20 +9,17 @@ package com.synopsys.integration.blackduck.imageinspector.api.name;
 
 import java.util.Optional;
 
+import com.synopsys.integration.blackduck.imageinspector.image.common.RepoTag;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.NameValuePair;
-import org.apache.http.message.BasicNameValuePair;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ImageNameResolver {
 
-    public NameValuePair resolve(@Nullable String foundImageName, @Nullable String givenRepo, @Nullable String givenTag) {
-        givenRepo = Optional.ofNullable(givenRepo).orElse("");
-        givenTag = Optional.ofNullable(givenTag).orElse("");
+    public RepoTag resolve(@Nullable String foundImageName, @Nullable String givenRepo, @Nullable String givenTag) {
         if (StringUtils.isBlank(foundImageName)) {
-            return new BasicNameValuePair(givenRepo, givenTag);
+            return new RepoTag(givenRepo, givenTag);
         }
         String resolvedImageRepo = givenRepo;
         String resolvedImageTag = givenTag;
@@ -38,7 +35,7 @@ public class ImageNameResolver {
                 }
             }
         }
-        return new BasicNameValuePair(resolvedImageRepo, resolvedImageTag);
+        return new RepoTag(resolvedImageRepo, resolvedImageTag);
     }
 
     private int findColonBeforeTag(final String givenImageName) {

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolver.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolver.java
@@ -10,12 +10,15 @@ package com.synopsys.integration.blackduck.imageinspector.api.name;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.jetbrains.annotations.Nullable;
 
 public class ImageNameResolver {
-    private Optional<String> newImageRepo = Optional.empty();
-    private Optional<String> newImageTag = Optional.empty();
 
-    public ImageNameResolver(final String givenImageName) {
+    public NameValuePair resolve(@Nullable String givenImageName) {
+        Optional<String> newImageRepo = Optional.empty();
+        Optional<String> newImageTag = Optional.empty();
         if (StringUtils.isNotBlank(givenImageName)) {
             newImageTag = Optional.of("latest");
             final int tagColonIndex = findColonBeforeTag(givenImageName);
@@ -28,14 +31,7 @@ public class ImageNameResolver {
                 }
             }
         }
-    }
-
-    public Optional<String> getNewImageRepo() {
-        return newImageRepo;
-    }
-
-    public Optional<String> getNewImageTag() {
-        return newImageTag;
+        return new BasicNameValuePair(newImageRepo.orElse(""), newImageTag.orElse(""));
     }
 
     private int findColonBeforeTag(final String givenImageName) {

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/containerfilesystem/ContainerFileSystemCompatibilityChecker.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/containerfilesystem/ContainerFileSystemCompatibilityChecker.java
@@ -10,13 +10,17 @@ package com.synopsys.integration.blackduck.imageinspector.containerfilesystem;
 import com.synopsys.integration.blackduck.imageinspector.containerfilesystem.pkgmgr.pkgmgrdb.PackageManagerToImageInspectorOsMapping;
 import com.synopsys.integration.blackduck.imageinspector.api.ImageInspectorOsEnum;
 import com.synopsys.integration.blackduck.imageinspector.api.WrongInspectorOsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ContainerFileSystemCompatibilityChecker {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public void checkInspectorOs(ContainerFileSystemWithPkgMgrDb containerFileSystemWithPkgMgrDb, ImageInspectorOsEnum currentOs) throws WrongInspectorOsException {
         if (containerFileSystemWithPkgMgrDb.getPkgMgr() == null) {
+            logger.warn("No linux package manager was found in this image");
             return; // if there's no pkg mgr in target image, any image inspector will do
         }
         final ImageInspectorOsEnum neededInspectorOs = PackageManagerToImageInspectorOsMapping

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/ImageDirectoryDataExtractor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/ImageDirectoryDataExtractor.java
@@ -25,7 +25,7 @@ public class ImageDirectoryDataExtractor {
     }
 
     public ImageDirectoryData extract(File imageDir, @Nullable String givenRepo, @Nullable String givenTag) throws IOException, IntegrationException {
-        List<TypedArchiveFile> unOrderedLayerArchives = imageDirectoryExtractor.getLayerArchives(imageDir);
+        List<TypedArchiveFile> unOrderedLayerArchives = imageDirectoryExtractor.getLayerArchives(imageDir, givenRepo, givenTag);
         FullLayerMapping fullLayerMapping = imageDirectoryExtractor.getLayerMapping(imageDir, givenRepo, givenTag);
         List<LayerDetailsBuilder> layerData = layerDataExtractor.getLayerData(unOrderedLayerArchives, fullLayerMapping);
         return new ImageDirectoryData(fullLayerMapping.getManifestLayerMapping().getImageName().orElse(null), fullLayerMapping.getManifestLayerMapping().getTagName().orElse(null), fullLayerMapping, layerData);

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/ImageDirectoryDataExtractor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/ImageDirectoryDataExtractor.java
@@ -13,7 +13,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.LinkedList;
 import java.util.List;
 
 public class ImageDirectoryDataExtractor {

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/ImageDirectoryExtractor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/ImageDirectoryExtractor.java
@@ -9,12 +9,13 @@ package com.synopsys.integration.blackduck.imageinspector.image.common;
 
 import com.synopsys.integration.blackduck.imageinspector.image.common.archive.TypedArchiveFile;
 import com.synopsys.integration.exception.IntegrationException;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
 public interface ImageDirectoryExtractor {
-    List<TypedArchiveFile> getLayerArchives(File imageDir) throws IntegrationException;
+    List<TypedArchiveFile> getLayerArchives(File imageDir, @Nullable String givenRepo, @Nullable String givenTag) throws IntegrationException;
     FullLayerMapping getLayerMapping(File imageDir, final String repo, final String tag) throws IntegrationException;
 }

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/ManifestRepoTagMatcher.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/ManifestRepoTagMatcher.java
@@ -1,0 +1,35 @@
+/*
+ * hub-imageinspector-lib
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.imageinspector.image.common;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+public class ManifestRepoTagMatcher {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    public Optional<String> findMatch(List<String> manifestRepoTags, String targetRepoTag) {
+        logger.debug(String.format("findRepoTag(): specifiedRepoTag: %s", targetRepoTag));
+        for (final String repoTag : manifestRepoTags) {
+            logger.trace(String.format("Target repo tag %s; checking %s", targetRepoTag, repoTag));
+            if (StringUtils.compare(repoTag, targetRepoTag) == 0) {
+                logger.trace(String.format("Found the targetRepoTag %s", targetRepoTag));
+                return Optional.of(repoTag);
+            }
+            if (targetRepoTag.endsWith("/" + repoTag)) {
+                logger.trace(String.format("Matched the targetRepoTag %s to %s by ignoring the repository prefix", targetRepoTag, repoTag));
+                return Optional.of(repoTag);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/RepoTag.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/RepoTag.java
@@ -18,6 +18,8 @@ public class RepoTag {
     @Nullable
     private final String tag;
 
+    // TODO there are many more places where this class should be used
+
     public RepoTag(@Nullable String repo, @Nullable String tag) {
         this.repo = repo;
         this.tag = tag;

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/RepoTag.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/RepoTag.java
@@ -1,0 +1,41 @@
+/*
+ * hub-imageinspector-lib
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.imageinspector.image.common;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class RepoTag {
+    @Nullable
+    private final String repo;
+    @Nullable
+    private final String tag;
+
+    public RepoTag(@Nullable String repo, @Nullable String tag) {
+        this.repo = repo;
+        this.tag = tag;
+    }
+
+    public Optional<String> getRepo() {
+        // translate both null and "" to empty to simplify life for callers
+        if (StringUtils.isBlank(repo)) {
+            return Optional.empty();
+        }
+        return Optional.of(repo);
+    }
+
+    public Optional<String> getTag() {
+        // translate both null and "" to empty to simplify life for callers
+        if (StringUtils.isBlank(tag)) {
+            return Optional.empty();
+        }
+        return Optional.of(tag);
+    }
+}

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/DockerImageDirectoryExtractor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/DockerImageDirectoryExtractor.java
@@ -18,6 +18,7 @@ import com.synopsys.integration.blackduck.imageinspector.image.common.FullLayerM
 import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestLayerMapping;
 import com.synopsys.integration.blackduck.imageinspector.linux.FileOperations;
 import com.synopsys.integration.exception.IntegrationException;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +43,7 @@ public class DockerImageDirectoryExtractor implements ImageDirectoryExtractor {
     }
 
     @Override
-    public List<TypedArchiveFile> getLayerArchives(File imageDir) throws IntegrationException {
+    public List<TypedArchiveFile> getLayerArchives(File imageDir, @Nullable String givenRepo, @Nullable String givenTag) throws IntegrationException {
         logger.debug(String.format("Searching for layer archive files in unpackedImageDir: %s", imageDir.getAbsolutePath()));
         final List<TypedArchiveFile> untaredLayerFiles = new ArrayList<>();
         List<File> unpackedImageTopLevelFiles = Arrays.asList(imageDir.listFiles());

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
@@ -54,7 +54,7 @@ public class DockerManifest extends Stringable {
                 continue;
             }
             logger.debug(String.format("foundRepoTag: %s", foundRepoTag.get()));
-            final NameValuePair resolvedRepoTag = imageNameResolver.resolve(foundRepoTag.get());
+            final NameValuePair resolvedRepoTag = imageNameResolver.resolve(foundRepoTag.get(), targetImageName, targetTagName);
             String resolvedRepo = resolvedRepoTag.getName();
             String resolvedTag = resolvedRepoTag.getValue();
             logger.debug(String.format("translated repoTag to: repo: %s, tag: %s", resolvedRepo, resolvedTag));

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.NameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,9 +52,11 @@ public class DockerManifest extends Stringable {
                 continue;
             }
             logger.debug(String.format("foundRepoTag: %s", foundRepoTag.get()));
-            final ImageNameResolver resolver = new ImageNameResolver(foundRepoTag.get());
-            logger.debug(String.format("translated repoTag to: repo: %s, tag: %s", resolver.getNewImageRepo().get(), resolver.getNewImageTag().get()));
-            return createMapping(image, resolver.getNewImageRepo().get(), resolver.getNewImageTag().get());
+            final NameValuePair resolvedRepoTag = (new ImageNameResolver()).resolve(foundRepoTag.get());
+            String resolvedRepo = resolvedRepoTag.getName();
+            String resolvedTag = resolvedRepoTag.getValue();
+            logger.debug(String.format("translated repoTag to: repo: %s, tag: %s", resolvedRepo, resolvedTag));
+            return createMapping(image, resolvedRepo, resolvedTag);
         }
         throw new IntegrationException(String.format("Layer mapping for repo:tag %s:%s not found in manifest.json", targetImageName, targetTagName));
     }

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
@@ -33,10 +33,12 @@ import com.synopsys.integration.util.Stringable;
 public class DockerManifest extends Stringable {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final ManifestRepoTagMatcher manifestRepoTagMatcher;
+    private final ImageNameResolver imageNameResolver;
     private final File tarExtractionDirectory;
 
-    public DockerManifest(ManifestRepoTagMatcher manifestRepoTagMatcher, File tarExtractionDirectory) {
+    public DockerManifest(ManifestRepoTagMatcher manifestRepoTagMatcher, ImageNameResolver imageNameResolver, File tarExtractionDirectory) {
         this.manifestRepoTagMatcher = manifestRepoTagMatcher;
+        this.imageNameResolver = imageNameResolver;
         this.tarExtractionDirectory = tarExtractionDirectory;
     }
 
@@ -52,7 +54,7 @@ public class DockerManifest extends Stringable {
                 continue;
             }
             logger.debug(String.format("foundRepoTag: %s", foundRepoTag.get()));
-            final NameValuePair resolvedRepoTag = (new ImageNameResolver()).resolve(foundRepoTag.get());
+            final NameValuePair resolvedRepoTag = imageNameResolver.resolve(foundRepoTag.get());
             String resolvedRepo = resolvedRepoTag.getName();
             String resolvedTag = resolvedRepoTag.getValue();
             logger.debug(String.format("translated repoTag to: repo: %s, tag: %s", resolvedRepo, resolvedTag));

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
@@ -12,7 +12,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -29,9 +31,11 @@ import com.synopsys.integration.util.Stringable;
 
 public class DockerManifest extends Stringable {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final ManifestRepoTagMatcher manifestRepoTagMatcher;
     private final File tarExtractionDirectory;
 
-    public DockerManifest(final File tarExtractionDirectory) {
+    public DockerManifest(ManifestRepoTagMatcher manifestRepoTagMatcher, File tarExtractionDirectory) {
+        this.manifestRepoTagMatcher = manifestRepoTagMatcher;
         this.tarExtractionDirectory = tarExtractionDirectory;
     }
 
@@ -42,39 +46,28 @@ public class DockerManifest extends Stringable {
         validateImageSpecificity(images, targetImageName, targetTagName);
         for (final DockerImageInfo image : images) {
             logger.trace(String.format("getLayerMappings(): image: %s", image));
-            final String foundRepoTag = findRepoTag(images.size(), image, targetImageName, targetTagName);
-            if (foundRepoTag == null) {
+            final Optional<String> foundRepoTag = findRepoTag(images.size(), image, targetImageName, targetTagName);
+            if (!foundRepoTag.isPresent()) {
                 continue;
             }
-            logger.debug(String.format("foundRepoTag: %s", foundRepoTag));
-            final ImageNameResolver resolver = new ImageNameResolver(foundRepoTag);
+            logger.debug(String.format("foundRepoTag: %s", foundRepoTag.get()));
+            final ImageNameResolver resolver = new ImageNameResolver(foundRepoTag.get());
             logger.debug(String.format("translated repoTag to: repo: %s, tag: %s", resolver.getNewImageRepo().get(), resolver.getNewImageTag().get()));
             return createMapping(image, resolver.getNewImageRepo().get(), resolver.getNewImageTag().get());
         }
         throw new IntegrationException(String.format("Layer mapping for repo:tag %s:%s not found in manifest.json", targetImageName, targetTagName));
     }
 
-    private String findRepoTag(final int numImages, final DockerImageInfo image, final String targetImageName, final String targetTagName) {
+    private Optional<String> findRepoTag(final int numImages, final DockerImageInfo image, final String targetImageName, final String targetTagName) {
         // user didn't specify which image, and there is only one: return it
         if (numImages == 1 && StringUtils.isBlank(targetImageName) && StringUtils.isBlank(targetTagName)) {
             logger.debug(String.format("User did not specify a repo:tag, and there's only one image; inspecting that one: %s", getRepoTag(image)));
-            return getRepoTag(image);
+            return Optional.of(getRepoTag(image));
         }
         final String targetRepoTag = deriveSpecifiedRepoTag(targetImageName, targetTagName);
-        logger.debug(String.format("findRepoTag(): specifiedRepoTag: %s", targetRepoTag));
-        for (final String repoTag : image.repoTags) {
-            logger.trace(String.format("Target repo tag %s; checking %s", targetRepoTag, repoTag));
-            if (StringUtils.compare(repoTag, targetRepoTag) == 0) {
-                logger.trace(String.format("Found the targetRepoTag %s", targetRepoTag));
-                return repoTag;
-            }
-            if (targetRepoTag.endsWith("/" + repoTag)) {
-                logger.trace(String.format("Matched the targetRepoTag %s to %s by ignoring the repository prefix", targetRepoTag, repoTag));
-                return repoTag;
-            }
-        }
-        return null;
+        return manifestRepoTagMatcher.findMatch(image.repoTags, targetRepoTag);
     }
+
 
     private String getRepoTag(final DockerImageInfo image) {
         if (image.repoTags == null || image.repoTags.isEmpty()) {

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifest.java
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.Optional;
 
 import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
+import com.synopsys.integration.blackduck.imageinspector.image.common.RepoTag;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.NameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,11 +54,9 @@ public class DockerManifest extends Stringable {
                 continue;
             }
             logger.debug(String.format("foundRepoTag: %s", foundRepoTag.get()));
-            final NameValuePair resolvedRepoTag = imageNameResolver.resolve(foundRepoTag.get(), targetImageName, targetTagName);
-            String resolvedRepo = resolvedRepoTag.getName();
-            String resolvedTag = resolvedRepoTag.getValue();
-            logger.debug(String.format("translated repoTag to: repo: %s, tag: %s", resolvedRepo, resolvedTag));
-            return createMapping(image, resolvedRepo, resolvedTag);
+            RepoTag resolvedRepoTag = imageNameResolver.resolve(foundRepoTag.get(), targetImageName, targetTagName);
+            logger.debug(String.format("translated repoTag to: repo: %s, tag: %s", resolvedRepoTag.getRepo().orElse(""), resolvedRepoTag.getTag().orElse("")));
+            return createMapping(image, resolvedRepoTag.getRepo().orElse(""), resolvedRepoTag.getTag().orElse(""));
         }
         throw new IntegrationException(String.format("Layer mapping for repo:tag %s:%s not found in manifest.json", targetImageName, targetTagName));
     }

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifestFactory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifestFactory.java
@@ -9,13 +9,14 @@ package com.synopsys.integration.blackduck.imageinspector.image.docker.manifest;
 
 import java.io.File;
 
+import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DockerManifestFactory {
 
     public DockerManifest createManifest(final File tarExtractionDirectory) {
-        final DockerManifest manifest = new DockerManifest(tarExtractionDirectory);
+        final DockerManifest manifest = new DockerManifest(new ManifestRepoTagMatcher(), tarExtractionDirectory);
         return manifest;
     }
 

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifestFactory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifestFactory.java
@@ -9,6 +9,7 @@ package com.synopsys.integration.blackduck.imageinspector.image.docker.manifest;
 
 import java.io.File;
 
+import com.synopsys.integration.blackduck.imageinspector.api.name.ImageNameResolver;
 import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +17,7 @@ import org.springframework.stereotype.Component;
 public class DockerManifestFactory {
 
     public DockerManifest createManifest(final File tarExtractionDirectory) {
-        final DockerManifest manifest = new DockerManifest(new ManifestRepoTagMatcher(), tarExtractionDirectory);
+        final DockerManifest manifest = new DockerManifest(new ManifestRepoTagMatcher(), new ImageNameResolver(), tarExtractionDirectory);
         return manifest;
     }
 

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryDataExtractorFactory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryDataExtractorFactory.java
@@ -38,7 +38,8 @@ public class OciImageDirectoryDataExtractorFactory implements ImageDirectoryData
     @Override
     public ImageDirectoryDataExtractor createImageDirectoryDataExtractor() {
         FileOperations fileOperations = new FileOperations();
-        OciImageDirectoryExtractor ociImageDirectoryExtractor = new OciImageDirectoryExtractor(gson, fileOperations, commonImageConfigParser);
+        OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
+        OciImageDirectoryExtractor ociImageDirectoryExtractor = new OciImageDirectoryExtractor(gson, fileOperations, commonImageConfigParser, ociImageIndexFileParser);
         ImageLayerSorter imageOrderedLayerExtractor = new OciImageLayerSorter();
         LayerDataExtractor layerDataExtractor = new LayerDataExtractor(imageOrderedLayerExtractor);
         return new ImageDirectoryDataExtractor(ociImageDirectoryExtractor, layerDataExtractor);

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryDataExtractorFactory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryDataExtractorFactory.java
@@ -10,12 +10,7 @@ package com.synopsys.integration.blackduck.imageinspector.image.oci;
 import java.io.File;
 
 import com.google.gson.Gson;
-import com.synopsys.integration.blackduck.imageinspector.image.common.CommonImageConfigParser;
-import com.synopsys.integration.blackduck.imageinspector.image.common.ImageDirectoryDataExtractor;
-import com.synopsys.integration.blackduck.imageinspector.image.common.ImageDirectoryDataExtractorFactory;
-import com.synopsys.integration.blackduck.imageinspector.image.common.ImageLayerMetadataExtractor;
-import com.synopsys.integration.blackduck.imageinspector.image.common.ImageLayerSorter;
-import com.synopsys.integration.blackduck.imageinspector.image.common.LayerDataExtractor;
+import com.synopsys.integration.blackduck.imageinspector.image.common.*;
 import com.synopsys.integration.blackduck.imageinspector.linux.FileOperations;
 import com.synopsys.integration.exception.IntegrationException;
 
@@ -39,7 +34,7 @@ public class OciImageDirectoryDataExtractorFactory implements ImageDirectoryData
     public ImageDirectoryDataExtractor createImageDirectoryDataExtractor() {
         FileOperations fileOperations = new FileOperations();
         OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
-        OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser();
+        OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser(new ManifestRepoTagMatcher());
         OciImageDirectoryExtractor ociImageDirectoryExtractor = new OciImageDirectoryExtractor(gson, fileOperations, commonImageConfigParser, ociImageIndexFileParser, ociManifestDescriptorParser);
         ImageLayerSorter imageOrderedLayerExtractor = new OciImageLayerSorter();
         LayerDataExtractor layerDataExtractor = new LayerDataExtractor(imageOrderedLayerExtractor);

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryDataExtractorFactory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryDataExtractorFactory.java
@@ -39,7 +39,8 @@ public class OciImageDirectoryDataExtractorFactory implements ImageDirectoryData
     public ImageDirectoryDataExtractor createImageDirectoryDataExtractor() {
         FileOperations fileOperations = new FileOperations();
         OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
-        OciImageDirectoryExtractor ociImageDirectoryExtractor = new OciImageDirectoryExtractor(gson, fileOperations, commonImageConfigParser, ociImageIndexFileParser);
+        OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser();
+        OciImageDirectoryExtractor ociImageDirectoryExtractor = new OciImageDirectoryExtractor(gson, fileOperations, commonImageConfigParser, ociImageIndexFileParser, ociManifestDescriptorParser);
         ImageLayerSorter imageOrderedLayerExtractor = new OciImageLayerSorter();
         LayerDataExtractor layerDataExtractor = new LayerDataExtractor(imageOrderedLayerExtractor);
         return new ImageDirectoryDataExtractor(ociImageDirectoryExtractor, layerDataExtractor);

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryDataExtractorFactory.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryDataExtractorFactory.java
@@ -10,6 +10,7 @@ package com.synopsys.integration.blackduck.imageinspector.image.oci;
 import java.io.File;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.blackduck.imageinspector.api.name.ImageNameResolver;
 import com.synopsys.integration.blackduck.imageinspector.image.common.*;
 import com.synopsys.integration.blackduck.imageinspector.linux.FileOperations;
 import com.synopsys.integration.exception.IntegrationException;
@@ -35,7 +36,8 @@ public class OciImageDirectoryDataExtractorFactory implements ImageDirectoryData
         FileOperations fileOperations = new FileOperations();
         OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
         OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser(new ManifestRepoTagMatcher());
-        OciImageDirectoryExtractor ociImageDirectoryExtractor = new OciImageDirectoryExtractor(gson, fileOperations, commonImageConfigParser, ociImageIndexFileParser, ociManifestDescriptorParser);
+        ImageNameResolver imageNameResolver = new ImageNameResolver();
+        OciImageDirectoryExtractor ociImageDirectoryExtractor = new OciImageDirectoryExtractor(gson, fileOperations, imageNameResolver, commonImageConfigParser, ociImageIndexFileParser, ociManifestDescriptorParser);
         ImageLayerSorter imageOrderedLayerExtractor = new OciImageLayerSorter();
         LayerDataExtractor layerDataExtractor = new LayerDataExtractor(imageOrderedLayerExtractor);
         return new ImageDirectoryDataExtractor(ociImageDirectoryExtractor, layerDataExtractor);

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractor.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 import com.synopsys.integration.blackduck.imageinspector.api.name.ImageNameResolver;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.NameValuePair;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,10 +88,10 @@ public class OciImageDirectoryExtractor implements ImageDirectoryExtractor {
         String actualTag = givenTag;
         if (manifestDescriptor.getRepoTagString().isPresent()) {
             logger.debug(String.format("foundRepoTag: %s", manifestDescriptor.getRepoTagString().get()));
-            final ImageNameResolver resolver = new ImageNameResolver(manifestDescriptor.getRepoTagString().get());
-            actualRepo = resolver.getNewImageRepo().orElse(givenRepo);
-            actualTag = resolver.getNewImageTag().orElse(givenTag);
-            logger.debug(String.format("Based on manifest, translated repoTag to: repo: %s, tag: %s", actualRepo, actualTag));
+            final NameValuePair resolvedRepoTag = (new ImageNameResolver()).resolve(manifestDescriptor.getRepoTagString().get());
+            String resolvedRepo = resolvedRepoTag.getName();
+            String resolvedTag = resolvedRepoTag.getValue();
+            logger.debug(String.format("Based on manifest, translated repoTag to: repo: %s, tag: %s", resolvedRepo, resolvedTag));
         }
         File manifestFile = findManifestFile(imageDir, manifestDescriptor);
         String manifestFileText;

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractor.java
@@ -48,16 +48,18 @@ public class OciImageDirectoryExtractor implements ImageDirectoryExtractor {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private Gson gson;
-    private FileOperations fileOperations;
+    private final Gson gson;
+    private final FileOperations fileOperations;
+    private final ImageNameResolver imageNameResolver;
     private final CommonImageConfigParser commonImageConfigParser;
     private final OciImageIndexFileParser ociImageIndexFileParser;
     private final OciManifestDescriptorParser ociManifestDescriptorParser;
 
-    public OciImageDirectoryExtractor(final Gson gson, FileOperations fileOperations, CommonImageConfigParser commonImageConfigParser,
+    public OciImageDirectoryExtractor(final Gson gson, FileOperations fileOperations, ImageNameResolver imageNameResolver, CommonImageConfigParser commonImageConfigParser,
                                       OciImageIndexFileParser ociImageIndexFileParser, OciManifestDescriptorParser ociManifestDescriptorParser) {
         this.gson = gson;
         this.fileOperations = fileOperations;
+        this.imageNameResolver = imageNameResolver;
         this.commonImageConfigParser = commonImageConfigParser;
         this.ociImageIndexFileParser = ociImageIndexFileParser;
         this.ociManifestDescriptorParser = ociManifestDescriptorParser;
@@ -88,7 +90,7 @@ public class OciImageDirectoryExtractor implements ImageDirectoryExtractor {
         String actualTag = givenTag;
         if (manifestDescriptor.getRepoTagString().isPresent()) {
             logger.debug(String.format("foundRepoTag: %s", manifestDescriptor.getRepoTagString().get()));
-            final NameValuePair resolvedRepoTag = (new ImageNameResolver()).resolve(manifestDescriptor.getRepoTagString().get());
+            final NameValuePair resolvedRepoTag = imageNameResolver.resolve(manifestDescriptor.getRepoTagString().get());
             String resolvedRepo = resolvedRepoTag.getName();
             String resolvedTag = resolvedRepoTag.getValue();
             logger.debug(String.format("Based on manifest, translated repoTag to: repo: %s, tag: %s", resolvedRepo, resolvedTag));

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractor.java
@@ -16,17 +16,13 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.synopsys.integration.blackduck.imageinspector.api.name.ImageNameResolver;
+import com.synopsys.integration.blackduck.imageinspector.image.common.*;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.NameValuePair;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
-import com.synopsys.integration.blackduck.imageinspector.image.common.CommonImageConfigParser;
-import com.synopsys.integration.blackduck.imageinspector.image.common.FullLayerMapping;
-import com.synopsys.integration.blackduck.imageinspector.image.common.ImageDirectoryExtractor;
-import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestLayerMapping;
 import com.synopsys.integration.blackduck.imageinspector.image.common.archive.ArchiveFileType;
 import com.synopsys.integration.blackduck.imageinspector.image.common.archive.TypedArchiveFile;
 import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciDescriptor;
@@ -86,8 +82,8 @@ public class OciImageDirectoryExtractor implements ImageDirectoryExtractor {
         OciImageIndex ociImageIndex = extractOciImageIndex(imageDir);
         OciDescriptor manifestDescriptor = ociManifestDescriptorParser.getManifestDescriptor(ociImageIndex, givenRepo, givenTag);
         logger.debug(String.format("foundRepoTag: %s", manifestDescriptor.getRepoTagString().orElse("")));
-        NameValuePair resolvedRepoTag = imageNameResolver.resolve(manifestDescriptor.getRepoTagString().orElse(null), givenRepo, givenTag);
-        logger.debug(String.format("Based on manifest, translated repoTag to: repo: %s, tag: %s", resolvedRepoTag.getName(), resolvedRepoTag.getValue()));
+        RepoTag resolvedRepoTag = imageNameResolver.resolve(manifestDescriptor.getRepoTagString().orElse(null), givenRepo, givenTag);
+        logger.debug(String.format("Based on manifest, translated repoTag to: repo: %s, tag: %s", resolvedRepoTag.getRepo().orElse(""), resolvedRepoTag.getTag().orElse("")));
         File manifestFile = findManifestFile(imageDir, manifestDescriptor);
         String manifestFileText;
         try {
@@ -104,7 +100,7 @@ public class OciImageDirectoryExtractor implements ImageDirectoryExtractor {
                                             .map(OciDescriptor::getDigest)
                                             .collect(Collectors.toList());
 
-        ManifestLayerMapping manifestLayerMapping = new ManifestLayerMapping(resolvedRepoTag.getName(), resolvedRepoTag.getValue(), pathToImageConfigFileFromRoot, layerInternalIds);
+        ManifestLayerMapping manifestLayerMapping = new ManifestLayerMapping(resolvedRepoTag.getRepo().orElse(""), resolvedRepoTag.getTag().orElse(""), pathToImageConfigFileFromRoot, layerInternalIds);
 
         List<String> layerExternalIds = commonImageConfigParser.getExternalLayerIdsFromImageConfigFile(imageDir, pathToImageConfigFileFromRoot);
         return new FullLayerMapping(manifestLayerMapping, layerExternalIds);

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParser.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParser.java
@@ -9,17 +9,14 @@ package com.synopsys.integration.blackduck.imageinspector.image.oci;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
-import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciDescriptor;
 import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciImageIndex;
 import com.synopsys.integration.blackduck.imageinspector.linux.FileOperations;
 import com.synopsys.integration.exception.IntegrationException;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Optional;
 
 public class OciImageIndexFileParser {
-    private static final String MANIFEST_FILE_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json";
     private final Gson gson;
     private final FileOperations fileOperations;
 
@@ -27,6 +24,8 @@ public class OciImageIndexFileParser {
         this.gson = gson;
         this.fileOperations = fileOperations;
     }
+
+    // TODO separate reading and parsing?
 
     public OciImageIndex loadIndex(File indexFile) throws IntegrationException {
         String indexFileText;
@@ -43,29 +42,6 @@ public class OciImageIndexFileParser {
             throw new IntegrationException(String.format("Error parsing %s: %s", indexFile.getAbsolutePath(), e.getMessage()));
         }
         return imageIndex;
-    }
-
-    // TODO do these methods really belong in the same class??
-
-    public String parseManifestFileDigestFromImageIndex(OciImageIndex imageIndex) throws IntegrationException {
-        String manifestFileDigest = null;
-        for (OciDescriptor manifestData : imageIndex.getManifests()) {
-            if (manifestData.getMediaType().equals(MANIFEST_FILE_MEDIA_TYPE)) {
-                if (manifestFileDigest == null) {
-                    manifestFileDigest = manifestData.getDigest();
-                    break;
-                } else {
-                    //TODO- what to do if we find multiple manifests?  OCI specs mention sometimes there's one for each supported architecture
-                    // we'd throw some kind of error, but should look into any pre-defined defaults that may inform us which one to pick (eg. re: architecture)
-                    throw new RuntimeException(String.format("Found multiple manifest files: %s and %s.  Please specify which image to target.  See help for information on how to do so.", manifestFileDigest, manifestData.getDigest()));
-                }
-            }
-        }
-        // Per specs, the size of OciImageIndex.manifests may be 0, but we require it
-        if (manifestFileDigest == null) {
-            throw new IntegrationException(String.format("Manifest with media type %s not found in OCI image index", MANIFEST_FILE_MEDIA_TYPE));
-        }
-        return manifestFileDigest;
     }
 
 }

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParser.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParser.java
@@ -1,0 +1,71 @@
+/*
+ * hub-imageinspector-lib
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.imageinspector.image.oci;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciDescriptor;
+import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciImageIndex;
+import com.synopsys.integration.blackduck.imageinspector.linux.FileOperations;
+import com.synopsys.integration.exception.IntegrationException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+public class OciImageIndexFileParser {
+    private static final String MANIFEST_FILE_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json";
+    private final Gson gson;
+    private final FileOperations fileOperations;
+
+    public OciImageIndexFileParser(Gson gson, FileOperations fileOperations) {
+        this.gson = gson;
+        this.fileOperations = fileOperations;
+    }
+
+    public OciImageIndex loadIndex(File indexFile) throws IntegrationException {
+        String indexFileText;
+        try {
+            indexFileText = fileOperations.readFileToString(indexFile);
+        } catch (IOException e) {
+            throw new IntegrationException(String.format("Error reading %s: %s", indexFile, e.getMessage()));
+        }
+
+        OciImageIndex imageIndex;
+        try {
+            imageIndex = gson.fromJson(indexFileText, OciImageIndex.class);
+        } catch (JsonSyntaxException e) {
+            throw new IntegrationException(String.format("Error parsing %s: %s", indexFile.getAbsolutePath(), e.getMessage()));
+        }
+        return imageIndex;
+    }
+
+    // TODO do these methods really belong in the same class??
+
+    public String parseManifestFileDigestFromImageIndex(OciImageIndex imageIndex) throws IntegrationException {
+        String manifestFileDigest = null;
+        for (OciDescriptor manifestData : imageIndex.getManifests()) {
+            if (manifestData.getMediaType().equals(MANIFEST_FILE_MEDIA_TYPE)) {
+                if (manifestFileDigest == null) {
+                    manifestFileDigest = manifestData.getDigest();
+                    break;
+                } else {
+                    //TODO- what to do if we find multiple manifests?  OCI specs mention sometimes there's one for each supported architecture
+                    // we'd throw some kind of error, but should look into any pre-defined defaults that may inform us which one to pick (eg. re: architecture)
+                    throw new RuntimeException(String.format("Found multiple manifest files: %s and %s.  Please specify which image to target.  See help for information on how to do so.", manifestFileDigest, manifestData.getDigest()));
+                }
+            }
+        }
+        // Per specs, the size of OciImageIndex.manifests may be 0, but we require it
+        if (manifestFileDigest == null) {
+            throw new IntegrationException(String.format("Manifest with media type %s not found in OCI image index", MANIFEST_FILE_MEDIA_TYPE));
+        }
+        return manifestFileDigest;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciManifestDescriptorParser.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciManifestDescriptorParser.java
@@ -7,25 +7,67 @@
  */
 package com.synopsys.integration.blackduck.imageinspector.image.oci;
 
+import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
 import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciDescriptor;
 import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciImageIndex;
 import com.synopsys.integration.exception.IntegrationException;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class OciManifestDescriptorParser {
     private static final String MANIFEST_FILE_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json";
+    private final ManifestRepoTagMatcher manifestRepoTagMatcher;
 
-    public OciDescriptor getManifestDescriptor(OciImageIndex ociImageIndex) throws IntegrationException {
-        // TODO right now this just returns the first one; probably not adequate
-        // Probably need to be able to select one of many (based on repo:tag? and/or arch maybe?)
-        for (OciDescriptor manifestData : ociImageIndex.getManifests()) {
-            if (manifestData.getMediaType().equals(MANIFEST_FILE_MEDIA_TYPE)) {
-                    return manifestData;
-            }
-        }
-        throw new IntegrationException(String.format("Manifest descriptor with media type %s not found in OCI image index", MANIFEST_FILE_MEDIA_TYPE));
+    public OciManifestDescriptorParser(ManifestRepoTagMatcher manifestRepoTagMatcher) {
+        this.manifestRepoTagMatcher = manifestRepoTagMatcher;
     }
 
-    public String getManifestFileDigest(OciImageIndex ociImageIndex) throws IntegrationException {
-        return getManifestDescriptor(ociImageIndex).getDigest();
+    public OciDescriptor getManifestDescriptor(OciImageIndex ociImageIndex,
+                                               @Nullable String givenRepo, @Nullable String givenTag) throws IntegrationException {
+        // Probably also need to select one of multiple based on arch
+        List<OciDescriptor> trueManifests =
+                ociImageIndex.getManifests().stream()
+                        .filter(man -> MANIFEST_FILE_MEDIA_TYPE.equals(man.getMediaType()))
+                        .collect(Collectors.toList());
+        if (trueManifests.size() == 0) {
+            throw new IntegrationException(String.format("No manifest descriptor with media type %s was found in OCI image index", MANIFEST_FILE_MEDIA_TYPE));
+        }
+        if ((trueManifests.size() == 1) && StringUtils.isBlank(givenRepo)) {
+            return trueManifests.get(0);
+        }
+        if (StringUtils.isBlank(givenTag)) {
+            givenTag = "latest";
+        }
+        // Both repo and tag have values
+        String givenRepoTag = String.format("%s:%s", givenRepo, givenTag);
+
+        // TODO is there a simpler way to do this?
+        List <String> manifestRepTagStrings = trueManifests.stream()
+                .map(OciDescriptor::getRepoTagString)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+        Optional<String> matchingManifestRepoTagString = manifestRepoTagMatcher.findMatch(manifestRepTagStrings, givenRepoTag);
+        if (!matchingManifestRepoTagString.isPresent()) {
+            throw new IntegrationException(String.format("No manifest found matching given repo:tag: %s", givenRepoTag));
+        }
+        // We know which repo:tag we want; return manifest matching that
+        Optional<OciDescriptor> matchingManifest = trueManifests.stream()
+                .filter(m -> m.getRepoTagString().isPresent())
+                .filter(m -> m.getRepoTagString().get().equals(matchingManifestRepoTagString.get()))
+                .findFirst();
+        if (!matchingManifest.isPresent()) {
+            throw new IntegrationException(String.format("Unable to find manifest matching repo:tag: %s", matchingManifestRepoTagString.get()));
+        }
+        return matchingManifest.get();
+    }
+
+    public String getManifestFileDigest(OciImageIndex ociImageIndex,
+                                        @Nullable String givenRepo, @Nullable String givenTag) throws IntegrationException {
+        return getManifestDescriptor(ociImageIndex, givenRepo, givenTag).getDigest();
     }
 }

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciManifestDescriptorParser.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciManifestDescriptorParser.java
@@ -1,0 +1,31 @@
+/*
+ * hub-imageinspector-lib
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.imageinspector.image.oci;
+
+import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciDescriptor;
+import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciImageIndex;
+import com.synopsys.integration.exception.IntegrationException;
+
+public class OciManifestDescriptorParser {
+    private static final String MANIFEST_FILE_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json";
+
+    public OciDescriptor getManifestDescriptor(OciImageIndex ociImageIndex) throws IntegrationException {
+        // TODO right now this just returns the first one; probably not adequate
+        // Probably need to be able to select one of many (based on repo:tag? and/or arch maybe?)
+        for (OciDescriptor manifestData : ociImageIndex.getManifests()) {
+            if (manifestData.getMediaType().equals(MANIFEST_FILE_MEDIA_TYPE)) {
+                    return manifestData;
+            }
+        }
+        throw new IntegrationException(String.format("Manifest descriptor with media type %s not found in OCI image index", MANIFEST_FILE_MEDIA_TYPE));
+    }
+
+    public String getManifestFileDigest(OciImageIndex ociImageIndex) throws IntegrationException {
+        return getManifestDescriptor(ociImageIndex).getDigest();
+    }
+}

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/model/OciDescriptor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/model/OciDescriptor.java
@@ -9,10 +9,14 @@ package com.synopsys.integration.blackduck.imageinspector.image.oci.model;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import com.google.gson.annotations.SerializedName;
 
 public class OciDescriptor {
+    private static final String REP_TAG_ANNOTATION_KEY = "org.opencontainers.image.ref.name";
+
     @SerializedName("mediaType")
     private String mediaType;
 
@@ -22,8 +26,8 @@ public class OciDescriptor {
     @SerializedName("size")
     private String size;
 
-    // annotations looks potentially useful (sometimes has repo:tag), but also problematic: spec says it should be
-    // an array of strings, but buildah gives it a single string (non-array) value. I've removed the reference for now.
+    @SerializedName("annotations")
+    private Map<String, String> annotations;
 
     public OciDescriptor(final String mediaType, final String digest, final String size) {
         this.mediaType = mediaType;
@@ -41,5 +45,20 @@ public class OciDescriptor {
 
     public String getSize() {
         return size;
+    }
+
+    public Optional<Map<String, String>> getAnnotations() {
+        return Optional.ofNullable(annotations);
+    }
+
+    public Optional<String> getAnnotation(String key) {
+        if (annotations == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(annotations.get(key));
+    }
+
+    public Optional<String> getRepoTagString() {
+        return getAnnotation(REP_TAG_ANNOTATION_KEY);
     }
 }

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/model/OciDescriptor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/model/OciDescriptor.java
@@ -47,6 +47,8 @@ public class OciDescriptor {
         return size;
     }
 
+    // TODO The following methods probably belong in a separate class to keep this class a pure model class
+
     public Optional<Map<String, String>> getAnnotations() {
         return Optional.ofNullable(annotations);
     }

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolverTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolverTest.java
@@ -23,49 +23,49 @@ public class ImageNameResolverTest {
 
     @Test
     public void testSimple() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine:latest");
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine:latest", null, null);
         assertEquals("alpine", resolvedRepoTag.getName());
         assertEquals("latest", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testNullLiterals() {
-        NameValuePair resolvedRepoTag = resolver.resolve("null:null");
-        assertEquals("null", resolvedRepoTag.getName());
-        assertEquals("null", resolvedRepoTag.getValue());
+        NameValuePair resolvedRepoTag = resolver.resolve(null, "givenRepo", "givenTag");
+        assertEquals("givenRepo", resolvedRepoTag.getName());
+        assertEquals("givenTag", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithoutTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine");
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine", null, null);
         assertEquals("alpine", resolvedRepoTag.getName());
         assertEquals("latest", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithUrlPortTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo:tag");
+        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo:tag", null, null);
         assertEquals("https://artifactory.team.domain.com:5002/repo", resolvedRepoTag.getName());
         assertEquals("tag", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithUrlPortNoTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo");
+        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo", null, null);
         assertEquals("https://artifactory.team.domain.com:5002/repo", resolvedRepoTag.getName());
         assertEquals("latest", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithUrlTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo:tag");
+        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo:tag", null, null);
         assertEquals("https://artifactory.team.domain.com/repo", resolvedRepoTag.getName());
         assertEquals("tag", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithUrlNoTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo");
+        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo", null, null);
         assertEquals("https://artifactory.team.domain.com/repo", resolvedRepoTag.getName());
         assertEquals("latest", resolvedRepoTag.getValue());
     }
@@ -73,42 +73,42 @@ public class ImageNameResolverTest {
 
     @Test
     public void testNull() {
-        NameValuePair resolvedRepoTag = resolver.resolve(null);
+        NameValuePair resolvedRepoTag = resolver.resolve(null, null, null);
         assertEquals("", resolvedRepoTag.getName());
         assertEquals("", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testNone() {
-        NameValuePair resolvedRepoTag = resolver.resolve("");
+        NameValuePair resolvedRepoTag = resolver.resolve("", null, null);
         assertEquals("", resolvedRepoTag.getName());
         assertEquals("", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testRepoOnly() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine");
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine", null, null);
         assertEquals("alpine", resolvedRepoTag.getName());
         assertEquals("latest", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testBoth() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine:1.0");
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine:1.0", null, null);
         assertEquals("alpine", resolvedRepoTag.getName());
         assertEquals("1.0", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testBothColonInRepoSpecifier() {
-        NameValuePair resolvedRepoTag = resolver.resolve("artifactoryserver:5000/alpine:1.0");
+        NameValuePair resolvedRepoTag = resolver.resolve("artifactoryserver:5000/alpine:1.0", null, null);
         assertEquals("artifactoryserver:5000/alpine", resolvedRepoTag.getName());
         assertEquals("1.0", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testEndsWithColon() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine:");
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine:", "", "");
         assertEquals("alpine", resolvedRepoTag.getName());
         assertEquals("latest", resolvedRepoTag.getValue());
     }

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolverTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolverTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.http.NameValuePair;
+import com.synopsys.integration.blackduck.imageinspector.image.common.RepoTag;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -23,94 +23,94 @@ public class ImageNameResolverTest {
 
     @Test
     public void testSimple() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine:latest", null, null);
-        assertEquals("alpine", resolvedRepoTag.getName());
-        assertEquals("latest", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("alpine:latest", null, null);
+        assertEquals("alpine", resolvedRepoTag.getRepo().get());
+        assertEquals("latest", resolvedRepoTag.getTag().get());
     }
 
     @Test
     public void testNullLiterals() {
-        NameValuePair resolvedRepoTag = resolver.resolve(null, "givenRepo", "givenTag");
-        assertEquals("givenRepo", resolvedRepoTag.getName());
-        assertEquals("givenTag", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve(null, "givenRepo", "givenTag");
+        assertEquals("givenRepo", resolvedRepoTag.getRepo().get());
+        assertEquals("givenTag", resolvedRepoTag.getTag().get());
     }
 
     @Test
     public void testWithoutTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine", null, null);
-        assertEquals("alpine", resolvedRepoTag.getName());
-        assertEquals("latest", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("alpine", null, null);
+        assertEquals("alpine", resolvedRepoTag.getRepo().get());
+        assertEquals("latest", resolvedRepoTag.getTag().get());
     }
 
     @Test
     public void testWithUrlPortTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo:tag", null, null);
-        assertEquals("https://artifactory.team.domain.com:5002/repo", resolvedRepoTag.getName());
-        assertEquals("tag", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo:tag", null, null);
+        assertEquals("https://artifactory.team.domain.com:5002/repo", resolvedRepoTag.getRepo().get());
+        assertEquals("tag", resolvedRepoTag.getTag().get());
     }
 
     @Test
     public void testWithUrlPortNoTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo", null, null);
-        assertEquals("https://artifactory.team.domain.com:5002/repo", resolvedRepoTag.getName());
-        assertEquals("latest", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo", null, null);
+        assertEquals("https://artifactory.team.domain.com:5002/repo", resolvedRepoTag.getRepo().get());
+        assertEquals("latest", resolvedRepoTag.getTag().get());
     }
 
     @Test
     public void testWithUrlTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo:tag", null, null);
-        assertEquals("https://artifactory.team.domain.com/repo", resolvedRepoTag.getName());
-        assertEquals("tag", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo:tag", null, null);
+        assertEquals("https://artifactory.team.domain.com/repo", resolvedRepoTag.getRepo().get());
+        assertEquals("tag", resolvedRepoTag.getTag().get());
     }
 
     @Test
     public void testWithUrlNoTag() {
-        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo", null, null);
-        assertEquals("https://artifactory.team.domain.com/repo", resolvedRepoTag.getName());
-        assertEquals("latest", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo", null, null);
+        assertEquals("https://artifactory.team.domain.com/repo", resolvedRepoTag.getRepo().get());
+        assertEquals("latest", resolvedRepoTag.getTag().get());
     }
 
 
     @Test
     public void testNull() {
-        NameValuePair resolvedRepoTag = resolver.resolve(null, null, null);
-        assertEquals("", resolvedRepoTag.getName());
-        assertEquals("", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve(null, null, null);
+        assertFalse(resolvedRepoTag.getRepo().isPresent());
+        assertFalse(resolvedRepoTag.getTag().isPresent());
     }
 
     @Test
     public void testNone() {
-        NameValuePair resolvedRepoTag = resolver.resolve("", null, null);
-        assertEquals("", resolvedRepoTag.getName());
-        assertEquals("", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("", null, null);
+        assertFalse(resolvedRepoTag.getRepo().isPresent());
+        assertFalse(resolvedRepoTag.getTag().isPresent());
     }
 
     @Test
     public void testRepoOnly() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine", null, null);
-        assertEquals("alpine", resolvedRepoTag.getName());
-        assertEquals("latest", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("alpine", null, null);
+        assertEquals("alpine", resolvedRepoTag.getRepo().get());
+        assertEquals("latest", resolvedRepoTag.getTag().get());
     }
 
     @Test
     public void testBoth() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine:1.0", null, null);
-        assertEquals("alpine", resolvedRepoTag.getName());
-        assertEquals("1.0", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("alpine:1.0", null, null);
+        assertEquals("alpine", resolvedRepoTag.getRepo().get());
+        assertEquals("1.0", resolvedRepoTag.getTag().get());
     }
 
     @Test
     public void testBothColonInRepoSpecifier() {
-        NameValuePair resolvedRepoTag = resolver.resolve("artifactoryserver:5000/alpine:1.0", null, null);
-        assertEquals("artifactoryserver:5000/alpine", resolvedRepoTag.getName());
-        assertEquals("1.0", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("artifactoryserver:5000/alpine:1.0", null, null);
+        assertEquals("artifactoryserver:5000/alpine", resolvedRepoTag.getRepo().get());
+        assertEquals("1.0", resolvedRepoTag.getTag().get());
     }
 
     @Test
     public void testEndsWithColon() {
-        NameValuePair resolvedRepoTag = resolver.resolve("alpine:", "", "");
-        assertEquals("alpine", resolvedRepoTag.getName());
-        assertEquals("latest", resolvedRepoTag.getValue());
+        RepoTag resolvedRepoTag = resolver.resolve("alpine:", "", "");
+        assertEquals("alpine", resolvedRepoTag.getRepo().get());
+        assertEquals("latest", resolvedRepoTag.getTag().get());
     }
 
 }

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolverTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolverTest.java
@@ -4,14 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.http.NameValuePair;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ImageNameResolverTest {
+    private static ImageNameResolver resolver;
 
     @BeforeAll
     public static void setUpBeforeAll() throws Exception {
+        resolver = new ImageNameResolver();
     }
 
     @AfterAll
@@ -20,94 +23,94 @@ public class ImageNameResolverTest {
 
     @Test
     public void testSimple() {
-        final ImageNameResolver resolver = new ImageNameResolver("alpine:latest");
-        assertEquals("alpine", resolver.getNewImageRepo().get());
-        assertEquals("latest", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine:latest");
+        assertEquals("alpine", resolvedRepoTag.getName());
+        assertEquals("latest", resolvedRepoTag.getValue());
     }
 
     @Test
-    public void testNull() {
-        final ImageNameResolver resolver = new ImageNameResolver("null:null");
-        assertEquals("null", resolver.getNewImageRepo().get());
-        assertEquals("null", resolver.getNewImageTag().get());
+    public void testNullLiterals() {
+        NameValuePair resolvedRepoTag = resolver.resolve("null:null");
+        assertEquals("null", resolvedRepoTag.getName());
+        assertEquals("null", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithoutTag() {
-        final ImageNameResolver resolver = new ImageNameResolver("alpine");
-        assertEquals("alpine", resolver.getNewImageRepo().get());
-        assertEquals("latest", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine");
+        assertEquals("alpine", resolvedRepoTag.getName());
+        assertEquals("latest", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithUrlPortTag() {
-        final ImageNameResolver resolver = new ImageNameResolver("https://artifactory.team.domain.com:5002/repo:tag");
-        assertEquals("https://artifactory.team.domain.com:5002/repo", resolver.getNewImageRepo().get());
-        assertEquals("tag", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo:tag");
+        assertEquals("https://artifactory.team.domain.com:5002/repo", resolvedRepoTag.getName());
+        assertEquals("tag", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithUrlPortNoTag() {
-        final ImageNameResolver resolver = new ImageNameResolver("https://artifactory.team.domain.com:5002/repo");
-        assertEquals("https://artifactory.team.domain.com:5002/repo", resolver.getNewImageRepo().get());
-        assertEquals("latest", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo");
+        assertEquals("https://artifactory.team.domain.com:5002/repo", resolvedRepoTag.getName());
+        assertEquals("latest", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithUrlTag() {
-        final ImageNameResolver resolver = new ImageNameResolver("https://artifactory.team.domain.com/repo:tag");
-        assertEquals("https://artifactory.team.domain.com/repo", resolver.getNewImageRepo().get());
-        assertEquals("tag", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo:tag");
+        assertEquals("https://artifactory.team.domain.com/repo", resolvedRepoTag.getName());
+        assertEquals("tag", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testWithUrlNoTag() {
-        final ImageNameResolver resolver = new ImageNameResolver("https://artifactory.team.domain.com/repo");
-        assertEquals("https://artifactory.team.domain.com/repo", resolver.getNewImageRepo().get());
-        assertEquals("latest", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com/repo");
+        assertEquals("https://artifactory.team.domain.com/repo", resolvedRepoTag.getName());
+        assertEquals("latest", resolvedRepoTag.getValue());
+    }
+
+
+    @Test
+    public void testNull() {
+        NameValuePair resolvedRepoTag = resolver.resolve(null);
+        assertEquals("", resolvedRepoTag.getName());
+        assertEquals("", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testNone() {
-        final ImageNameResolver resolver = new ImageNameResolver("");
-        assertFalse(resolver.getNewImageRepo().isPresent());
-        assertFalse(resolver.getNewImageTag().isPresent());
+        NameValuePair resolvedRepoTag = resolver.resolve("");
+        assertEquals("", resolvedRepoTag.getName());
+        assertEquals("", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testRepoOnly() {
-        final ImageNameResolver resolver = new ImageNameResolver("alpine");
-        assertTrue(resolver.getNewImageRepo().isPresent());
-        assertTrue(resolver.getNewImageTag().isPresent());
-        assertEquals("alpine", resolver.getNewImageRepo().get());
-        assertEquals("latest", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine");
+        assertEquals("alpine", resolvedRepoTag.getName());
+        assertEquals("latest", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testBoth() {
-        final ImageNameResolver resolver = new ImageNameResolver("alpine:1.0");
-        assertTrue(resolver.getNewImageRepo().isPresent());
-        assertTrue(resolver.getNewImageTag().isPresent());
-        assertEquals("alpine", resolver.getNewImageRepo().get());
-        assertEquals("1.0", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine:1.0");
+        assertEquals("alpine", resolvedRepoTag.getName());
+        assertEquals("1.0", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testBothColonInRepoSpecifier() {
-        final ImageNameResolver resolver = new ImageNameResolver("artifactoryserver:5000/alpine:1.0");
-        assertTrue(resolver.getNewImageRepo().isPresent());
-        assertTrue(resolver.getNewImageTag().isPresent());
-        assertEquals("artifactoryserver:5000/alpine", resolver.getNewImageRepo().get());
-        assertEquals("1.0", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("artifactoryserver:5000/alpine:1.0");
+        assertEquals("artifactoryserver:5000/alpine", resolvedRepoTag.getName());
+        assertEquals("1.0", resolvedRepoTag.getValue());
     }
 
     @Test
     public void testEndsWithColon() {
-        final ImageNameResolver resolver = new ImageNameResolver("alpine:");
-        assertTrue(resolver.getNewImageRepo().isPresent());
-        assertTrue(resolver.getNewImageTag().isPresent());
-        assertEquals("alpine", resolver.getNewImageRepo().get());
-        assertEquals("latest", resolver.getNewImageTag().get());
+        NameValuePair resolvedRepoTag = resolver.resolve("alpine:");
+        assertEquals("alpine", resolvedRepoTag.getName());
+        assertEquals("latest", resolvedRepoTag.getValue());
     }
 
 }

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/docker/DockerImageDirectoryExtractorTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/docker/DockerImageDirectoryExtractorTest.java
@@ -29,7 +29,7 @@ public class DockerImageDirectoryExtractorTest {
         DockerManifestFactory dockerManifestFactory = new DockerManifestFactory();
         DockerImageDirectoryExtractor extractor = new DockerImageDirectoryExtractor(gson, fileOperations, commonImageConfigParser, dockerManifestFactory);
 
-        List<TypedArchiveFile> typedArchiveFiles = extractor.getLayerArchives(imageDir);
+        List<TypedArchiveFile> typedArchiveFiles = extractor.getLayerArchives(imageDir, null, null);
 
         assertEquals(1, typedArchiveFiles.size());
         assertEquals(ArchiveFileType.TAR, typedArchiveFiles.get(0).getType());
@@ -49,7 +49,7 @@ public class DockerImageDirectoryExtractorTest {
         DockerManifestFactory dockerManifestFactory = new DockerManifestFactory();
         DockerImageDirectoryExtractor extractor = new DockerImageDirectoryExtractor(gson, fileOperations, dockerImageConfigParser, dockerManifestFactory);
 
-        List<TypedArchiveFile> typedArchiveFiles = extractor.getLayerArchives(imageDir);
+        List<TypedArchiveFile> typedArchiveFiles = extractor.getLayerArchives(imageDir, "", "");
 
         assertEquals(1, typedArchiveFiles.size());
         assertEquals(ArchiveFileType.TAR, typedArchiveFiles.get(0).getType());

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifestTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifestTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
+import com.synopsys.integration.blackduck.imageinspector.api.name.ImageNameResolver;
 import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,7 @@ public class DockerManifestTest {
     public void test() throws IOException, IntegrationException {
         final File tarExtractionDirectory = new File("src/test/resources/extraction");
         final String dockerTarFileName = "alpine.tar";
-        DockerManifest manifest = new DockerManifest(new ManifestRepoTagMatcher(), new File(tarExtractionDirectory, dockerTarFileName));
+        DockerManifest manifest = new DockerManifest(new ManifestRepoTagMatcher(), new ImageNameResolver(), new File(tarExtractionDirectory, dockerTarFileName));
         final String targetImageName = "alpine";
         final String targetTagName = "latest";
         ManifestLayerMapping manifestLayerMapping = manifest.getLayerMapping(targetImageName, targetTagName);
@@ -33,7 +34,7 @@ public class DockerManifestTest {
     public void testRepoIncludesRegistryPrefix() throws IOException, IntegrationException {
         final File tarExtractionDirectory = new File("src/test/resources/extraction");
         final String dockerTarFileName = "alpine.tar";
-        DockerManifest manifest = new DockerManifest(new ManifestRepoTagMatcher(), new File(tarExtractionDirectory, dockerTarFileName));
+        DockerManifest manifest = new DockerManifest(new ManifestRepoTagMatcher(), new ImageNameResolver(), new File(tarExtractionDirectory, dockerTarFileName));
         final String targetImageName = "docker.io/alpine";
         final String targetTagName = "latest";
         ManifestLayerMapping manifestLayerMapping = manifest.getLayerMapping(targetImageName, targetTagName);

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifestTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/docker/manifest/DockerManifestTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
+import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
 import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestLayerMapping;
@@ -16,7 +17,7 @@ public class DockerManifestTest {
     public void test() throws IOException, IntegrationException {
         final File tarExtractionDirectory = new File("src/test/resources/extraction");
         final String dockerTarFileName = "alpine.tar";
-        DockerManifest manifest = new DockerManifest(new File(tarExtractionDirectory, dockerTarFileName));
+        DockerManifest manifest = new DockerManifest(new ManifestRepoTagMatcher(), new File(tarExtractionDirectory, dockerTarFileName));
         final String targetImageName = "alpine";
         final String targetTagName = "latest";
         ManifestLayerMapping manifestLayerMapping = manifest.getLayerMapping(targetImageName, targetTagName);
@@ -32,7 +33,7 @@ public class DockerManifestTest {
     public void testRepoIncludesRegistryPrefix() throws IOException, IntegrationException {
         final File tarExtractionDirectory = new File("src/test/resources/extraction");
         final String dockerTarFileName = "alpine.tar";
-        DockerManifest manifest = new DockerManifest(new File(tarExtractionDirectory, dockerTarFileName));
+        DockerManifest manifest = new DockerManifest(new ManifestRepoTagMatcher(), new File(tarExtractionDirectory, dockerTarFileName));
         final String targetImageName = "docker.io/alpine";
         final String targetTagName = "latest";
         ManifestLayerMapping manifestLayerMapping = manifest.getLayerMapping(targetImageName, targetTagName);

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractorTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractorTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import com.synopsys.integration.blackduck.imageinspector.api.name.ImageNameResolver;
 import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
@@ -38,7 +39,8 @@ public class OciImageDirectoryExtractorTest {
         FileOperations fileOperations = new FileOperations();
         CommonImageConfigParser configParser = new CommonImageConfigParser(gson);
         OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser(new ManifestRepoTagMatcher());
-        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(gson, fileOperations, configParser,
+        ImageNameResolver imageNameResolver = new ImageNameResolver();
+        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(gson, fileOperations, imageNameResolver, configParser,
                 new OciImageIndexFileParser(gson, fileOperations),
                 ociManifestDescriptorParser);
 
@@ -83,7 +85,8 @@ public class OciImageDirectoryExtractorTest {
         CommonImageConfigParser configParser = new CommonImageConfigParser(gson);
         OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
         OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser(new ManifestRepoTagMatcher());
-        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(gson, fileOperations, configParser, ociImageIndexFileParser,
+        ImageNameResolver imageNameResolver = new ImageNameResolver();
+        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(gson, fileOperations, imageNameResolver, configParser, ociImageIndexFileParser,
                 ociManifestDescriptorParser);
         File alpineOciImageDir = new File(imagePath);
 

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractorTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractorTest.java
@@ -32,8 +32,11 @@ public class OciImageDirectoryExtractorTest {
     @MethodSource("testParseLayerArchivesProvider")
     public void testParseLayerArchives(String testImagePath, List<TypedArchiveFile> expectedArchiveList) throws IntegrationException {
         File ociImageDir = new File(testImagePath);
-        CommonImageConfigParser configParser = new CommonImageConfigParser(new Gson());
-        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(new Gson(), new FileOperations(), configParser);
+        Gson gson = new Gson();
+        FileOperations fileOperations = new FileOperations();
+        CommonImageConfigParser configParser = new CommonImageConfigParser(gson);
+        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(gson, fileOperations, configParser,
+                new OciImageIndexFileParser(gson, fileOperations));
 
         List<TypedArchiveFile> layerArchives = extractor.getLayerArchives(ociImageDir);
         Assertions.assertEquals(expectedArchiveList.size(), layerArchives.size());
@@ -71,8 +74,11 @@ public class OciImageDirectoryExtractorTest {
     @ParameterizedTest
     @MethodSource("testGetLayerMappingProvider")
     public void testGetLayerMapping(String imagePath, FullLayerMapping expected) throws IntegrationException {
-        CommonImageConfigParser configParser = new CommonImageConfigParser(new Gson());
-        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(new Gson(), new FileOperations(), configParser);
+        Gson gson = new Gson();
+        FileOperations fileOperations = new FileOperations();
+        CommonImageConfigParser configParser = new CommonImageConfigParser(gson);
+        OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
+        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(gson, fileOperations, configParser, ociImageIndexFileParser);
         File alpineOciImageDir = new File(imagePath);
         String testRepo = "testRepo";
         String testTag = "testTag";

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractorTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractorTest.java
@@ -35,8 +35,10 @@ public class OciImageDirectoryExtractorTest {
         Gson gson = new Gson();
         FileOperations fileOperations = new FileOperations();
         CommonImageConfigParser configParser = new CommonImageConfigParser(gson);
+        OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser();
         OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(gson, fileOperations, configParser,
-                new OciImageIndexFileParser(gson, fileOperations));
+                new OciImageIndexFileParser(gson, fileOperations),
+                ociManifestDescriptorParser);
 
         List<TypedArchiveFile> layerArchives = extractor.getLayerArchives(ociImageDir);
         Assertions.assertEquals(expectedArchiveList.size(), layerArchives.size());
@@ -78,7 +80,9 @@ public class OciImageDirectoryExtractorTest {
         FileOperations fileOperations = new FileOperations();
         CommonImageConfigParser configParser = new CommonImageConfigParser(gson);
         OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
-        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(gson, fileOperations, configParser, ociImageIndexFileParser);
+        OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser();
+        OciImageDirectoryExtractor extractor = new OciImageDirectoryExtractor(gson, fileOperations, configParser, ociImageIndexFileParser,
+                ociManifestDescriptorParser);
         File alpineOciImageDir = new File(imagePath);
         String testRepo = "testRepo";
         String testTag = "testTag";

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParserTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParserTest.java
@@ -1,0 +1,73 @@
+package com.synopsys.integration.blackduck.imageinspector.image.oci;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciImageIndex;
+import com.synopsys.integration.blackduck.imageinspector.linux.FileOperations;
+import com.synopsys.integration.exception.IntegrationException;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OciImageIndexFileParserTest {
+
+    @Test
+    void testManifestDigest() throws IntegrationException {
+        File indexFile = new File("src/test/resources/oci/index_json/zero_annotations/index.json");
+        Gson gson = new Gson();
+        FileOperations fileOperations = new FileOperations();
+        OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
+
+        OciImageIndex ociImageIndex = ociImageIndexFileParser.loadIndex(indexFile);
+        assertEquals(1, ociImageIndex.getManifests().size());
+        String manifestDigest = ociImageIndexFileParser.parseManifestFileDigestFromImageIndex(ociImageIndex);
+        assertEquals("sha256:8bd1d67ebe6aeae405d824c21560ec9aa2371ed48aa0c4a833e4672cadb0cf3e", manifestDigest);
+    }
+
+    @Test
+    void testNoAnnotations() throws IntegrationException {
+        File indexFile = new File("src/test/resources/oci/index_json/zero_annotations/index.json");
+        Gson gson = new Gson();
+        FileOperations fileOperations = new FileOperations();
+        OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
+
+        OciImageIndex ociImageIndex = ociImageIndexFileParser.loadIndex(indexFile);
+        assertEquals(1, ociImageIndex.getManifests().size());
+        assertFalse(ociImageIndex.getManifests().get(0).getAnnotations().isPresent());
+    }
+
+    @Test
+    void testOneAnnotation() throws IntegrationException {
+        File indexFile = new File("src/test/resources/oci/index_json/single_annotation/index.json");
+        Gson gson = new Gson();
+        FileOperations fileOperations = new FileOperations();
+        OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
+
+        OciImageIndex ociImageIndex = ociImageIndexFileParser.loadIndex(indexFile);
+        assertEquals(1, ociImageIndex.getManifests().size());
+        assertTrue(ociImageIndex.getManifests().get(0).getAnnotations().isPresent());
+        assertEquals(1, ociImageIndex.getManifests().get(0).getAnnotations().get().size());
+        Map<String, String> annotations = ociImageIndex.getManifests().get(0).getAnnotations().get();
+        assertEquals("localhost/centosplus:1", annotations.get("org.opencontainers.image.ref.name"));
+        assertFalse(ociImageIndex.getManifests().get(0).getAnnotation("bogusKey").isPresent());
+        assertEquals("localhost/centosplus:1", ociImageIndex.getManifests().get(0).getAnnotation("org.opencontainers.image.ref.name").get());
+        assertEquals("localhost/centosplus:1", ociImageIndex.getManifests().get(0).getRepoTagString().get());
+    }
+
+    @Test
+    void testTwoAnnotations() throws IntegrationException {
+        File indexFile = new File("src/test/resources/oci/index_json/multiple_annotations/index.json");
+        Gson gson = new Gson();
+        FileOperations fileOperations = new FileOperations();
+        OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
+
+        OciImageIndex ociImageIndex = ociImageIndexFileParser.loadIndex(indexFile);
+        assertEquals(1, ociImageIndex.getManifests().size());
+
+        assertTrue(ociImageIndex.getManifests().get(0).getAnnotations().isPresent());
+        assertEquals(2, ociImageIndex.getManifests().get(0).getAnnotations().get().size());
+    }
+}

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParserTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParserTest.java
@@ -1,6 +1,7 @@
 package com.synopsys.integration.blackduck.imageinspector.image.oci;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.blackduck.imageinspector.image.common.ManifestRepoTagMatcher;
 import com.synopsys.integration.blackduck.imageinspector.image.oci.model.OciImageIndex;
 import com.synopsys.integration.blackduck.imageinspector.linux.FileOperations;
 import com.synopsys.integration.exception.IntegrationException;
@@ -24,8 +25,8 @@ public class OciImageIndexFileParserTest {
         OciImageIndex ociImageIndex = ociImageIndexFileParser.loadIndex(indexFile);
         // TODO this test is now cluttered / testing different classes
         // TODO need a test class for OciManifestDescriptorParser
-        OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser();
-        String manifestDigest = ociManifestDescriptorParser.getManifestFileDigest(ociImageIndex);
+        OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser(new ManifestRepoTagMatcher());
+        String manifestDigest = ociManifestDescriptorParser.getManifestFileDigest(ociImageIndex, "", "");
         //assertEquals(1, ociImageIndex.getManifests().size());
         //String manifestDigest = ociImageIndexFileParser.parseManifestFileDigestFromImageIndex(ociImageIndex);
         assertEquals("sha256:8bd1d67ebe6aeae405d824c21560ec9aa2371ed48aa0c4a833e4672cadb0cf3e", manifestDigest);

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParserTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageIndexFileParserTest.java
@@ -22,8 +22,12 @@ public class OciImageIndexFileParserTest {
         OciImageIndexFileParser ociImageIndexFileParser = new OciImageIndexFileParser(gson, fileOperations);
 
         OciImageIndex ociImageIndex = ociImageIndexFileParser.loadIndex(indexFile);
-        assertEquals(1, ociImageIndex.getManifests().size());
-        String manifestDigest = ociImageIndexFileParser.parseManifestFileDigestFromImageIndex(ociImageIndex);
+        // TODO this test is now cluttered / testing different classes
+        // TODO need a test class for OciManifestDescriptorParser
+        OciManifestDescriptorParser ociManifestDescriptorParser = new OciManifestDescriptorParser();
+        String manifestDigest = ociManifestDescriptorParser.getManifestFileDigest(ociImageIndex);
+        //assertEquals(1, ociImageIndex.getManifests().size());
+        //String manifestDigest = ociImageIndexFileParser.parseManifestFileDigestFromImageIndex(ociImageIndex);
         assertEquals("sha256:8bd1d67ebe6aeae405d824c21560ec9aa2371ed48aa0c4a833e4672cadb0cf3e", manifestDigest);
     }
 

--- a/src/test/resources/oci/index_json/multiple_annotations/index.json
+++ b/src/test/resources/oci/index_json/multiple_annotations/index.json
@@ -1,0 +1,6 @@
+{"schemaVersion":2,"manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:8bd1d67ebe6aeae405d824c21560ec9aa2371ed48aa0c4a833e4672cadb0cf3e","size":499,
+"annotations": {
+        "org.freedesktop.specifications.metainfo.version": "1.0",
+        "org.freedesktop.specifications.metainfo.type": "AppStream"
+      },
+"platform":{"architecture":"amd64","os":"linux"}}]}

--- a/src/test/resources/oci/index_json/single_annotation/index.json
+++ b/src/test/resources/oci/index_json/single_annotation/index.json
@@ -1,0 +1,1 @@
+{"schemaVersion":2,"manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:8bd1d67ebe6aeae405d824c21560ec9aa2371ed48aa0c4a833e4672cadb0cf3e","size":499,"annotations":{"org.opencontainers.image.ref.name":"localhost/centosplus:1"},"platform":{"architecture":"amd64","os":"linux"}}]}

--- a/src/test/resources/oci/index_json/zero_annotations/index.json
+++ b/src/test/resources/oci/index_json/zero_annotations/index.json
@@ -1,0 +1,2 @@
+{"schemaVersion":2,"manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:8bd1d67ebe6aeae405d824c21560ec9aa2371ed48aa0c4a833e4672cadb0cf3e","size":499,
+"platform":{"architecture":"amd64","os":"linux"}}]}


### PR DESCRIPTION
enhanced oci to extract the repo:tag from the manifest annotations if it's there, and use that to assist with: 1. selecting which of multiple images in a .tar is the target image, 2. codelocation naming, and 3. project name/version naming. I also modified the code to be stricter about the data docker inspector requires, by throwing exceptions when it's not there (even though the spec says its optional).