### PR TITLE
fix: Support OCI-format images created using Docker Engine 25.x and above

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/ImageInspectorApi.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/ImageInspectorApi.java
@@ -117,8 +117,8 @@ public class ImageInspectorApi {
         }
 
         List<ImageDirectoryDataExtractorFactory> imageDirectoryDataExtractorFactories = Arrays.asList(
-            new DockerImageDirectoryDataExtractorFactory(new DockerImageFormatMatchesChecker(), new CommonImageConfigParser(gson), gson),
-            new OciImageDirectoryDataExtractorFactory(new OciImageFormatMatchesChecker(new OciLayoutParser(gson)), new CommonImageConfigParser(gson), gson)
+            new OciImageDirectoryDataExtractorFactory(new OciImageFormatMatchesChecker(new OciLayoutParser(gson)), new CommonImageConfigParser(gson), gson),
+            new DockerImageDirectoryDataExtractorFactory(new DockerImageFormatMatchesChecker(), new CommonImageConfigParser(gson), gson)
         );
         ImageInfoDerived imageInfoDerived = null;
         try {


### PR DESCRIPTION
### Description
Fix for the issue seen in IDOCKER-785 which started occurring after Docker 25.x started creating OCI-compliant image tar files with `docker save`. (Till Docker 24.x, these images were in the Docker format, not OCI compliant)

- Docker inspector supports both Docker-format images and OCI-format Docker images. 
- The primary check DI uses to determine if an image is in the Docker-format is by checking if it contains a manifest.json file.
- The primary check used to determine if the image is in the OCI-format is by checking if it contains an oci-layout file.
- When images were built with Docker engine v24.x or lower.
    - The docker save command created images in the Docker-format which only contain a manifest.json. 
    - OCI-format images were not created by docker save (these can be created using tools other than Docker) and these images only contain (and need) an index.json
- Now, with Docker engine v25.x, `docker save` creates images that are OCI-compliant. So the tar files include an index.json (as it should) AND a manifest.json (likely for backward compatibility).
- In the above case, DI saw the manifest.json in the customer’s OCI-compliant image, resolved it as a Docker-format image and attempted to extract image details from the same using the Docker-extractor instead of the OCI-extractor.
- The fix simply requires us to switch the order in which these checks happened. (For reference, [please see here](https://github.com/blackducksoftware/hub-imageinspector-lib/blob/a167a396f586f371329147794b54dcd063f3d14e/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/common/ImageDirectoryDataExtractorFactoryChooser.java#L26) - the loop that chooses the extractor breaks after it has successfully identified if the image is an OCI-format image or Docker-format image.

### JIRA
IDOCKER-785