### PR TITLE
Move image name resolution logic for OCI images from resolver to OCI extractor

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolver.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolver.java
@@ -23,13 +23,6 @@ public class ImageNameResolver {
         if (StringUtils.isBlank(foundImageName)) {
             return new RepoTag(givenRepo, givenTag);
         }
-        if (!foundImageName.contains(":")) {
-            if (givenTag.isBlank()) {
-                givenTag = "latest";
-            }
-            logger.trace(String.format("foundImageName %s in the manifest is not in repo:tag format, hence resolver will not use foundImageName for name resolution. Resolving RepoTag with givenRepo as %s and givenTag as %s", foundImageName, givenRepo, givenTag));
-            return new RepoTag(givenRepo, givenTag);
-        }
         String resolvedImageRepo = givenRepo;
         String resolvedImageTag = givenTag;
         if (StringUtils.isNotBlank(foundImageName)) {

--- a/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractor.java
+++ b/src/main/java/com/synopsys/integration/blackduck/imageinspector/image/oci/OciImageDirectoryExtractor.java
@@ -11,10 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-
-import javax.swing.text.html.Option;
 
 import com.synopsys.integration.blackduck.imageinspector.api.name.ImageNameResolver;
 import com.synopsys.integration.blackduck.imageinspector.image.common.*;

--- a/src/test/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolverTest.java
+++ b/src/test/java/com/synopsys/integration/blackduck/imageinspector/api/name/ImageNameResolverTest.java
@@ -36,6 +36,13 @@ public class ImageNameResolverTest {
     }
 
     @Test
+    public void testWithoutTag() {
+        RepoTag resolvedRepoTag = resolver.resolve("alpine", null, null);
+        assertEquals("alpine", resolvedRepoTag.getRepo().get());
+        assertEquals("latest", resolvedRepoTag.getTag().get());
+    }
+
+    @Test
     public void testWithUrlPortTag() {
         RepoTag resolvedRepoTag = resolver.resolve("https://artifactory.team.domain.com:5002/repo:tag", null, null);
         assertEquals("https://artifactory.team.domain.com:5002/repo", resolvedRepoTag.getRepo().get());


### PR DESCRIPTION
The ImageNameResolver.resolve() method is also used by the [detect-docker-inspector](https://github.com/blackducksoftware/detect-docker-inspector) project in addition to the callers in this library. This was causing 2 end-to-end integration tests to fail in the docker inspector project.

Moved this logic to the OCI extractor just before the resolve() method is called so that only the OCI image extractor uses this logic and no other caller of the resolver is affected.