### PR TITLE
Update to logback version 1.2.13.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     api 'org.springframework:spring-context'
     api 'org.apache.commons:commons-exec:1.3'
     implementation 'com.github.luben:zstd-jni:1.5.0-4'
-    implementation 'ch.qos.logback:logback-classic:1.4.14'
+    implementation 'ch.qos.logback:logback-classic:1.2.13'
 
     testImplementation 'org.mockito:mockito-all:1.10.19'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'


### PR DESCRIPTION
We are downgrading to 1.2.13 for logback to be consistent with the one to be used in the solutions.