### PR TITLE
Bump to version of common-gradle-plugin: 2.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     apply from: "https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle", to: buildscript
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-cgp-version.gradle'
 
-    dependencies { classpath "com.synopsys.integration:common-gradle-plugin:1.12.0" }
+    dependencies { classpath "com.synopsys.integration:common-gradle-plugin:2.0.4" }
 
     dependencies {
         classpath 'com.bmuschko:gradle-docker-plugin:6.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     apply from: "https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle", to: buildscript
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-cgp-version.gradle'
 
-    dependencies { classpath "com.synopsys.integration:common-gradle-plugin:2.0.4" }
+    dependencies { classpath "com.synopsys.integration:common-gradle-plugin:${managedCgpVersion}" }
 
     dependencies {
         classpath 'com.bmuschko:gradle-docker-plugin:6.7.0'


### PR DESCRIPTION
Bump to version of common-gradle-plugin: 2.0.4 to fix release job error.