### PR TITLE
fix: CentOS 7 based Docker test configuration to use Vault as the yum repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ task createTestDockerfile(type: Dockerfile) {
 task copyTestDockerFile(type: Exec) {
     ignoreExitValue true
     commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
-    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
+    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula/Dockerfile"
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {

--- a/build.gradle
+++ b/build.gradle
@@ -53,13 +53,13 @@ task removeTestImage(type: Exec) {
 
 task removeTestBaseImage(type: Exec) {
     ignoreExitValue true
-    commandLine "docker", "rmi", "centos:7.3.1611"
+    commandLine "docker", "rmi", "quay.io/centos/centos:centos7.3.1611"
 }
 
 task createTestDockerfile(type: Dockerfile) {
     destFile = project.file("${buildDir}/images/test/centos_minus_vim_plus_bacula/Dockerfile")
     println "destFile: ${destFile}"
-    from 'centos:7.3.1611'
+    from 'quay.io/centos/centos:centos7.3.1611'
     environmentVariable('LANG', 'en_US.UTF-8')
 
     runCommand 'rpm -e vim-minimal && \

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ task copyTestDockerFile(type: Exec) {
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {
     commandLine "docker", "build", "--no-cache", "--tag", "blackducksoftware/centos_minus_vim_plus_bacula:1.0",     \
-            "${buildDir}/images/test"
+            "src/test/resources"
 }
 
 task buildTestDockerTarfile(type: Exec, dependsOn: buildTestDockerImage) {

--- a/build.gradle
+++ b/build.gradle
@@ -71,12 +71,12 @@ task createTestDockerfile(type: Dockerfile) {
 
 task copyTestDockerFile(type: Exec, dependsOn: [createImagesDir]) {
 //    commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
-    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula/"
+    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/Dockerfile"
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {
     commandLine "docker", "build", "--no-cache", "--tag", "blackducksoftware/centos_minus_vim_plus_bacula:1.0",     \
-            "${buildDir}/images/test/centos_minus_vim_plus_bacula"
+            "${buildDir}/images/test"
 }
 
 task buildTestDockerTarfile(type: Exec, dependsOn: buildTestDockerImage) {
@@ -118,7 +118,7 @@ task pullAlpineLatest(type: Exec) {
 }
 
 task createImagesDir(type: Exec) {
-    commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
+    commandLine "mkdir", "-p", "${buildDir}/images/test"
 }
 
 task buildAlpineTestDockerTarfile(type: Exec, dependsOn: [createImagesDir, pullAlpineLatest]) {

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ task createTestDockerfile(type: Dockerfile) {
         bacula-console-5.2.13-23.1.el7'
 }
 
-task copyTestDockerFile(type: Exec, dependsOn: [createImagesDir]) {
+task copyTestDockerFile(type: Exec) {
 //    commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
     commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/Dockerfile"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ task createTestDockerfile(type: Dockerfile) {
 
 task copyTestDockerFile(type: Exec) {
     ignoreExitValue true
-    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula/Dockerfile"
+    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {

--- a/build.gradle
+++ b/build.gradle
@@ -61,16 +61,12 @@ task createTestDockerfile(type: Dockerfile) {
     println "destFile: ${destFile}"
     from 'centos:7.3.1611'
     environmentVariable('LANG', 'en_US.UTF-8')
-
-
-
     runCommand 'rpm -e vim-minimal && \
         yum install -y bacula-director-5.2.13-23.1.el7 bacula-storage-5.2.13-23.1.el7 bacula-client-5.2.13-23.1.el7 \
         bacula-console-5.2.13-23.1.el7'
 }
 
 task copyTestDockerFile(type: Exec) {
-//    commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
     commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/Dockerfile"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,9 +70,8 @@ task createTestDockerfile(type: Dockerfile) {
 }
 
 task copyTestDockerFile(type: Exec) {
-    ignoreExitValue true
     commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
-    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula/Dockerfile"
+    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {

--- a/build.gradle
+++ b/build.gradle
@@ -53,21 +53,28 @@ task removeTestImage(type: Exec) {
 
 task removeTestBaseImage(type: Exec) {
     ignoreExitValue true
-    commandLine "docker", "rmi", "quay.io/centos/centos:centos7.3.1611"
+    commandLine "docker", "rmi", "centos:7.3.1611"
 }
 
 task createTestDockerfile(type: Dockerfile) {
     destFile = project.file("${buildDir}/images/test/centos_minus_vim_plus_bacula/Dockerfile")
     println "destFile: ${destFile}"
-    from 'quay.io/centos/centos:centos7.3.1611'
+    from 'centos:7.3.1611'
     environmentVariable('LANG', 'en_US.UTF-8')
+
+
 
     runCommand 'rpm -e vim-minimal && \
         yum install -y bacula-director-5.2.13-23.1.el7 bacula-storage-5.2.13-23.1.el7 bacula-client-5.2.13-23.1.el7 \
         bacula-console-5.2.13-23.1.el7'
 }
 
-task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, createTestDockerfile]) {
+task copyTestDockerFile(type: Exec) {
+    ignoreExitValue true
+    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula/Dockerfile"
+}
+
+task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {
     commandLine "docker", "build", "--no-cache", "--tag", "blackducksoftware/centos_minus_vim_plus_bacula:1.0",     \
             "${buildDir}/images/test/centos_minus_vim_plus_bacula"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     apply from: "https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle", to: buildscript
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-cgp-version.gradle'
 
-    dependencies { classpath "com.synopsys.integration:common-gradle-plugin:${managedCgpVersion}" }
+    dependencies { classpath "com.synopsys.integration:common-gradle-plugin:2.0.4" }
 
     dependencies {
         classpath 'com.bmuschko:gradle-docker-plugin:6.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,8 @@ task createTestDockerfile(type: Dockerfile) {
 
 task copyTestDockerFile(type: Exec) {
     ignoreExitValue true
-    commandLine "mkdir", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
-    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula/"
+    commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
+    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,8 @@ task createTestDockerfile(type: Dockerfile) {
 
 task copyTestDockerFile(type: Exec) {
     ignoreExitValue true
-    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
+    commandLine "mkdir", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
+    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula/"
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     apply from: "https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle", to: buildscript
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-cgp-version.gradle'
 
-    dependencies { classpath "com.synopsys.integration:common-gradle-plugin:2.0.4" }
+    dependencies { classpath "com.synopsys.integration:common-gradle-plugin:${managedCgpVersion}" }
 
     dependencies {
         classpath 'com.bmuschko:gradle-docker-plugin:6.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ task createTestDockerfile(type: Dockerfile) {
 
 task copyTestDockerFile(type: Exec) {
     commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
-    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
+    commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula/"
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {

--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,8 @@ task createTestDockerfile(type: Dockerfile) {
         bacula-console-5.2.13-23.1.el7'
 }
 
-task copyTestDockerFile(type: Exec) {
-    commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
+task copyTestDockerFile(type: Exec, dependsOn: [createImagesDir]) {
+//    commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
     commandLine "cp", "src/test/resources/Dockerfile", "${buildDir}/images/test/centos_minus_vim_plus_bacula/"
 }
 
@@ -118,7 +118,7 @@ task pullAlpineLatest(type: Exec) {
 }
 
 task createImagesDir(type: Exec) {
-    commandLine "mkdir", "-p", "${buildDir}/images/test"
+    commandLine "mkdir", "-p", "${buildDir}/images/test/centos_minus_vim_plus_bacula"
 }
 
 task buildAlpineTestDockerTarfile(type: Exec, dependsOn: [createImagesDir, pullAlpineLatest]) {

--- a/src/test/resources/CentOS-Base.repo
+++ b/src/test/resources/CentOS-Base.repo
@@ -1,0 +1,24 @@
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://vault.centos.org/7.3.1611/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://vault.centos.org/7.3.1611/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://vault.centos.org/7.3.1611/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[centosplus]
+name=CentOS-$releasever - Plus
+baseurl=http://vault.centos.org/7.3.1611/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/src/test/resources/Dockerfile
+++ b/src/test/resources/Dockerfile
@@ -2,5 +2,5 @@ FROM centos:7.3.1611
 ENV LANG=en_US.UTF-8
 
 RUN rm -f /etc/yum.repos.d/CentOS-Base.repo
-COPY src/test/resources/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
+COPY CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
 RUN rpm -e vim-minimal && yum install -y bacula-director-5.2.13-23.1.el7 bacula-storage-5.2.13-23.1.el7 bacula-client-5.2.13-23.1.el7 bacula-console-5.2.13-23.1.el7

--- a/src/test/resources/Dockerfile
+++ b/src/test/resources/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:7.3.1611
+ENV LANG=en_US.UTF-8
+
+RUN rm -f /etc/yum.repos.d/CentOS-Base.repo
+COPY src/test/resources/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
+RUN rpm -e vim-minimal && yum install -y bacula-director-5.2.13-23.1.el7 bacula-storage-5.2.13-23.1.el7 bacula-client-5.2.13-23.1.el7 bacula-console-5.2.13-23.1.el7


### PR DESCRIPTION
CentOS 7 met End of Life on June 30th 2024.
Hence, effective July 1st 2024, CentOS 7 packages are no longer available under `mirrorlist.centos.org`. These packages have been archived at `vault.centos.org` starting from May 31, 2024 and we have updated the yum repository configuration file to fetch the packages from this archive.