### PR TITLE
Update default platform for gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ task copyTestDockerFile(type: Exec) {
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, copyTestDockerFile]) {
-    commandLine "docker", "build", "--no-cache", "--tag", "blackducksoftware/centos_minus_vim_plus_bacula:1.0",     \
+    commandLine "docker", "build", "--no-cache", "--platform=linux/amd64", "--tag", "blackducksoftware/centos_minus_vim_plus_bacula:1.0",     \
             "src/test/resources"
 }
 


### PR DESCRIPTION
This is so that local builds on the new Macs (arm64) pass without a hitch. 