### PR TITLE
Update dependencies for EU CRA fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaSourceCompatibility = 8
     }
     ext['logback.version'] = '1.2.13'
-    ext['json-path.version'] = '2.9.0'
+    ext['json-path.version'] = '2.10.0'
     ext['json-smart.version'] = '2.6.0'
     dependencies { classpath "com.blackduck.integration:common-gradle-plugin:${managedCgpVersion}" }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'com.blackduck.integration.library'
 dependencyManagement {
     imports {
         mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
-        mavenBom 'com.fasterxml.jackson:jackson-bom:2.12.4'
+        mavenBom 'com.fasterxml.jackson:jackson-bom:2.18.6'
     }
     dependencies {
         dependency 'ch.qos.logback:logback-core:1.2.13'
@@ -42,7 +42,7 @@ dependencyManagement {
 }
 
 dependencies {
-    api 'com.blackduck.integration:integration-bdio:27.0.2'
+    api 'com.blackduck.integration:integration-bdio:27.0.5'
     api 'org.springframework:spring-context:5.3.34'
     api 'org.apache.commons:commons-exec:1.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ buildscript {
         javaSourceCompatibility = 8
     }
     ext['logback.version'] = '1.2.13'
+    ext['json-path.version'] = '2.9.0'
+    ext['json-smart.version'] = '2.6.0'
     dependencies { classpath "com.blackduck.integration:common-gradle-plugin:${managedCgpVersion}" }
 
     dependencies {


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5086

**Description**

 This pull request bumps `integration-bdio` version to `27.0.5`. The `integration-bdio:27.0.5` pulls `integration-common:27.0.4` which updates transitive dependencies `json-path` from `2.9.0` to `2.10.0` to resolve a transitive vulnerable dependency as part of the EU CRA compliance effort.
 
`json-path:2.9.0` pulls in `json-smart:2.5.0`, which carries **CVE-2024-57699 (BDSA-2025-0966)**. 
This update transitively brings in `json-smart:2.6.0`, which is free of this vulnerability, and thus the safe version flows to all downstream consumers automatically.

Additionally, another updated dependency is `com.fasterxml.jackson:jackson-bom:2.18.6`

And, the following overrides were applied,

```groovy
ext['tomcat.version'] = '9.0.117'
ext['json-path.version'] = '2.10.0'
ext['json-smart.version'] = '2.6.0'
```

---

**Notes**

The `io.spring.dependency-management` plugin imports a Spring Boot BOM, which manages versions for common libraries (`json-path`, `json-smart`, `jackson`, etc.). **BOM managed versions take precedence over both gradle constraints blocks and `resolutionStrategy.force()` directives, silently downgrading explicitly pinned versions.**

So, every project that imports a Spring Boot BOM must independently override the BOM properties for any dependency it needs at a different version.

That's why `json-smart` and `json-path` overrides were applied and Jackson BOM upgraded from `2.12.4` to `2.18.6` in the `dependencyManagement` block to avoid this problem.
